### PR TITLE
Add LogLevel setting so the agent compiles

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,12 @@ type Settings struct {
 
 	WithoutSSL  bool `yaml:"without-ssl"`  // Default to SSL
 	NoMigration bool `yaml:"no-migration"` // Developer only
+
+	// LogLevel quietens the postgres server when set. Accepts postgres
+	// levels (debug5..debug1, log, notice, warning, error, fatal, panic);
+	// empty = the image default (chatty). Consumed in runtime.go to pass
+	// `-c log_min_messages=<level>` to the server (Docker + nix paths).
+	LogLevel string `yaml:"log-level"`
 }
 
 const HotReload = "hot-reload"


### PR DESCRIPTION
`runtime.go` already references `s.LogLevel` (Docker + nix runtime paths pass it as `-c log_min_messages=<level>`), but the `Settings` struct never declared the field, so the agent failed to build:

```
./runtime.go:156:58: s.LogLevel undefined (type *Runtime has no field or method LogLevel)
./runtime.go:190:48: s.LogLevel undefined
```

This adds the missing `log-level` setting (postgres levels `debug5..panic`; empty = image default). Consumers (e.g. mind's `service.codefly.yaml`) already set `log-level: warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `log-level` configuration option that allows you to control PostgreSQL log verbosity. This setting determines the minimum message level logged by PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->